### PR TITLE
Upgrade mongodb to 2.2.33

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Jira link(s)
+
+
+
+# What
+
+
+
+# Why
+
+
+
+
+# How
+
+
+
+# Verification Steps
+
+
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
 language: node_js
-services: mongodb
 sudo: required
 node_js:
-  - "0.11"
-  - "0.10"
-  - "4"
-  - "5"
-  - "6"
-script: make test-once
-before_script:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-  - sudo apt-get update
-  - sudo apt-get install -y mongodb-org=2.6.6 mongodb-org-server=2.6.6 mongodb-org-shell=2.6.6 mongodb-org-mongos=2.6.6 mongodb-org-tools=2.6.6
-  - sleep 15 #mongo may not be responded directly. See http://docs.travis-ci.com/user/database-setup/#MongoDB
-  - mongo --version
-after_script: make test-coveralls
+  - 6
+services:
+  - redis-server
+  - mongodb
 before_install:
-  # Travis uses an ancient GCC
-  - export CC="gcc-4.9" CXX="g++-4.9"
-  # node 0.8 comes with a non-functional version of npm
-  - "if [[ $(node --version) == v0.8.* ]]; then npm install -g npm@2.1.18; fi"
+  - sudo apt-get update
+  - sudo apt-get install --assume-yes apache2-utils
+  - npm config set strict-ssl false
+install: npm install
+env:
+  - MONGODB_VERSION=2.4
+  - MONGODB_VERSION=3.2
+script:
+  - make test-once
+after_script: make test-coveralls

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-agenda",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Temporary Clone Of Agenda To Work With Mongo 2.4. Do Not Use This.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "date.js": "~0.3.1",
     "human-interval": "~0.1.3",
     "moment-timezone": "^0.5.0",
-    "mongodb": "2.1.11"
+    "mongodb": "2.2.33"
   },
   "devDependencies": {
     "blanket": "1.1.5",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21766


# What
- Upgrade mongodb to 2.2.33
- Update travis in order to use the current version to test it.

# Why
- Solve CVEs get bug fixs



# How
npm install --save --save-exact mongodb@2.2.33


# Verification Steps
- Check the CI. All tests worked for both versions used in the of MongoDB and NodeJS 6. 


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 